### PR TITLE
conversation cards only for answers

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -46,8 +46,8 @@
   }
 }
 
-//create conversation cards
-.topic-post:not(.comment) .topic-body {
+//create conversations cards
+.answer .topic-body {
   @include boxShadow;
   background-color: lighten($secondary, 10%);
   margin-top: 10px;


### PR DESCRIPTION
sadly we can't put a card over the entire [answer[vote body] comment] thing because they are 2 separate elements (fuck you qa devs)
putting a card over the answer[vote body] is awkward -- the right side overflows, and the answer buttons inherit the boxshadow styles too, not to mention comments being singled out